### PR TITLE
Add hipsparse to cmake

### DIFF
--- a/examples/cg/CMakeLists.txt
+++ b/examples/cg/CMakeLists.txt
@@ -88,6 +88,8 @@ add_custom_command(
 find_package(hip REQUIRED)
 find_package(rocprim REQUIRED CONFIG)
 find_package(rocthrust REQUIRED CONFIG)
+find_package(hipsparse REQUIRED CONFIG)
+
 if(profiling)
 	find_library(ROCTRACER_LIBRARY NAMES roctracer64)
 	find_library(ROCTX64_LIBRARY NAMES roctx64)


### PR DESCRIPTION
Without this change
```bash
Consolidate compiler generated dependencies of target cg
[ 25%] Linking CXX executable cg
ld.lld: error: unable to find library -lhipsparse
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/cg.dir/build.make:129: cg] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/cg.dir/all] Error 2
make: *** [Makefile:91: all] Error 2

```